### PR TITLE
Version 2

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,6 +22,8 @@ async function getOS(distribution) {
 
 async function main() {
     try {
+        const targetArchitecture = core.getInput("target_architecture") || "armhf"
+
         const sourceRelativeDirectory = core.getInput("source_directory") || "./"
         const artifactsRelativeDirectory = core.getInput("artifacts_directory") || "./"
 
@@ -98,11 +100,11 @@ async function main() {
             core.endGroup()
         }
 
-        core.startGroup("Add armhf architecture")
+        core.startGroup("Add target architecture")
         await exec.exec("docker", [
             "exec",
             container,
-            "dpkg", "--add-architecture", "armhf"
+            "dpkg", "--add-architecture", targetArchitecture
         ])
         core.endGroup()
 
@@ -118,7 +120,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts", "equivs", "libpython3.7-minimal:armhf"
+            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts", "equivs", "libpython3.7-minimal:" + targetArchitecture
         ])
         core.endGroup()
 
@@ -134,7 +136,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "dpkg-buildpackage", "--no-sign", "-d", "-aarmhf"
+            "dpkg-buildpackage", "--no-sign", "-d", "-a" + targetArchitecture
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -109,7 +109,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "-yq", "dpkg-dev", "debhelper"
+            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts"
         ])
         core.endGroup()
 
@@ -117,7 +117,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "build-dep", "-yq", sourceDirectory
+            "mk-build-deps", "-ir", "-t", "apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends"
         ])
         core.endGroup()
 
@@ -125,7 +125,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "dpkg-buildpackage", "-tc"
+            "dpkg-buildpackage", "--no-sign", "-d", "-aarmhf"
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -98,6 +98,14 @@ async function main() {
             core.endGroup()
         }
 
+        core.startGroup("Add armhf architecture")
+        await exec.exec("docker", [
+            "exec",
+            container,
+            "dpkg", "--add-architecture", "armhf"
+        ])
+        core.endGroup()
+
         core.startGroup("Update packages list")
         await exec.exec("docker", [
             "exec",

--- a/main.js
+++ b/main.js
@@ -109,7 +109,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts"
+            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts", "equivs"
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -65,6 +65,7 @@ async function main() {
             "--name", container,
             "--volume", workspaceDirectory + ":" + workspaceDirectory,
             "--workdir", sourceDirectory,
+            "--env", "DH_VERBOSE=1",
             "--env", "DEBIAN_FRONTEND=noninteractive",
             "--env", "DPKG_COLORS=always",
             "--env", "FORCE_UNSAFE_CONFIGURE=1",

--- a/main.js
+++ b/main.js
@@ -145,7 +145,7 @@ async function main() {
             "find",
             buildDirectory,
             "-maxdepth", "1",
-            "-name", `${package}*${version}*.*`,
+            "-name", `*${version}*.*`,
             "-type", "f",
             "-print",
             "-exec", "mv", "{}", artifactsDirectory, ";"

--- a/main.js
+++ b/main.js
@@ -120,7 +120,12 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts", "equivs", "libpython3.7-minimal:" + targetArchitecture
+            "apt-get", "install", "--no-install-recommends", "-y",
+            // General packaging stuff
+            "dpkg-dev",
+            "debhelper",
+            // Used by pybuild
+            "libpython3.7-minimal:" + targetArchitecture
         ])
         core.endGroup()
 
@@ -128,7 +133,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "mk-build-deps", "-ir", "-t", "apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends"
+            "apt-get", "build-dep", "-y", sourceDirectory
         ])
         core.endGroup()
 
@@ -136,7 +141,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "dpkg-buildpackage", "--no-sign", "-d", "-a" + targetArchitecture
+            "dpkg-buildpackage", "--no-sign", "-a" + targetArchitecture
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -126,7 +126,8 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "dpkg-buildpackage", "--no-sign", "-d", "-aarmhf"
+            // "dpkg-buildpackage", "--no-sign", "-d", "-aarmhf"
+            "dpkg-buildpackage", "--no-sign", "-d", "-aamd64"
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -110,7 +110,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts", "equivs"
+            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts", "equivs", "libpython3.7-minimal:armhf"
         ])
         core.endGroup()
 
@@ -126,8 +126,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            // "dpkg-buildpackage", "--no-sign", "-d", "-aarmhf"
-            "dpkg-buildpackage", "--no-sign", "-d", "-aamd64"
+            "dpkg-buildpackage", "--no-sign", "-d", "-aarmhf"
         ])
         core.endGroup()
 


### PR DESCRIPTION
* Allow selection of target architecture
* Make `dpkg-buildpackage` verbose
* Make `apt-get` verbose
* Add support for pybuild packages (via `libpython3.7-minimal`)
