### PR TITLE
Support multiple architectures, passing build opts and installing dev packages from backports

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,15 +13,15 @@ inputs:
     required: false
     default: "./"
   target_architectures:
-    description: Target architectures to build for
+    description: Comma-separated options list of target architectures to build for
     required: false
     default: ""
   dpkg_buildpackage_opts:
-    description: Options list provided to 'dpkg-buildpackage' as command line parameters (note that '-a' is automatically provided for target architectures specified by target_architectures)
+    description: Comma-separated options list provided to 'dpkg-buildpackage' as command line parameters (note that '-a' is automatically provided for target architectures specified by target_architectures)
     required: false
     default: "--no-sign, -d"
   lintian_opts:
-    description: Options list provided to 'lintian' as command line parameters
+    description: Comma-separated options list provided to 'lintian' as command line parameters
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,19 @@ inputs:
     description: Directory where build artifacts will be placed, relative to workspace
     required: false
     default: ./
-  target_architecture:
+  target_architectures:
     description: Target architecture of Debian package to build
     required: false
-    default: "armhf"
+    default: []
+  dpkg_buildpackage_opts:
+    description: Options list provided to 'dpkg-buildpackage' as command line parameters (note that '-a' is automatically provided for target architectures specified by target_architectures)
+    required: false
+    default: [ "--no-sign", "-d" ]
+  lintian_opts:
+    description: Options list provided to 'lintian' as command line parameters
+    required: false
+    default: []
+
 runs:
   using: node12
   main: main.js

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: "./"
   target_architectures:
-    description: Target architecture of Debian package to build
+    description: Target architectures to build for
     required: false
     default: ""
   dpkg_buildpackage_opts:

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: Comma-separated options list provided to 'lintian' as command line parameters
     required: false
     default: ""
+  get_dev_packages_from_backports:
+    description: Only set to 1 if you know what you are doing. All other values are considered as 0
+    required: false
+    default: "0"
 
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -7,23 +7,23 @@ inputs:
   source_directory:
     description: Directory where Debian sources are, relative to workspace
     required: false
-    default: ./
+    default: "./"
   artifacts_directory:
     description: Directory where build artifacts will be placed, relative to workspace
     required: false
-    default: ./
+    default: "./"
   target_architectures:
     description: Target architecture of Debian package to build
     required: false
-    default: []
+    default: ""
   dpkg_buildpackage_opts:
     description: Options list provided to 'dpkg-buildpackage' as command line parameters (note that '-a' is automatically provided for target architectures specified by target_architectures)
     required: false
-    default: [ "--no-sign", "-d" ]
+    default: "--no-sign, -d"
   lintian_opts:
     description: Options list provided to 'lintian' as command line parameters
     required: false
-    default: []
+    default: ""
 
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Directory where build artifacts will be placed, relative to workspace
     required: false
     default: ./
+  target_architecture:
+    description: Target architecture of Debian package to build
+    required: false
+    default: "armhf"
 runs:
   using: node12
   main: main.js

--- a/main.js
+++ b/main.js
@@ -117,12 +117,12 @@ async function main() {
         }
 
         if (targetArchitectures.length != 0) {
-            for (targetArchitecture in targetArchitectures) {
+            targetArchitectures.forEach(targetArchitecture => {
                 runDockerExecStep(
                     "Add target architecture: " + targetArchitecture,
                     ["dpkg", "--add-architecture", targetArchitecture]
                 )
-            }
+            })
         }
 
         runDockerExecStep(
@@ -139,9 +139,9 @@ async function main() {
             ]
 
             // Used by pybuild
-            for (targetArchitecture in targetArchitectures) {
+            targetArchitectures.forEach(targetArchitecture => {
                 devPackages.concat("libpython3.7-minimal:" + targetArchitecture)
-            }
+            })
 
             return devPackages
         }
@@ -157,7 +157,7 @@ async function main() {
             ["apt-get", "build-dep", "-y", sourceDirectory]
         )
 
-        for (targetArchitecture in targetArchitectures) {
+        targetArchitectures.forEach(targetArchitecture => {
             runDockerExecStep(
                 "Build package for architecture: " + targetArchitecture,
                 [
@@ -165,7 +165,7 @@ async function main() {
                     "-a" + targetArchitecture
                 ].concat(dpkgBuildPackageOpts)
             )
-        }
+        })
 
         runDockerExecStep(
             "Run static analysis",

--- a/main.js
+++ b/main.js
@@ -154,7 +154,7 @@ async function main() {
 
         for (targetArchitecture in targetArchitectures) {
             runDockerExecStep(
-                "Build package",
+                "Build package for architecture: " + targetArchitecture,
                 [
                     "dpkg-buildpackage",
                     "-a" + targetArchitecture

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ async function getOS(distribution) {
 
 async function main() {
     try {
-        const targetArchitectures = core.getInput("target_architectures").replaceAll(" ", "").split(",") || []
+        const targetArchitectures = core.getInput("target_architectures").replace(" ", "").split(",") || []
 
         const sourceRelativeDirectory = core.getInput("source_directory") || "./"
         const artifactsRelativeDirectory = core.getInput("artifacts_directory") || "./"
@@ -35,7 +35,7 @@ async function main() {
             // (Seems to not recognize that some packages are installed)
             "-d"
         ]
-        const dpkgBuildPackageOpts = core.getInput("dpkg_buildpackage_opts").replaceAll(" ", "").split(",") || defaultDpkgBuildPackageOpts
+        const dpkgBuildPackageOpts = core.getInput("dpkg_buildpackage_opts").replace(" ", "").split(",") || defaultDpkgBuildPackageOpts
         const lintianOpts = core.getInput("lintian_opts") || []
 
         const workspaceDirectory = process.cwd()

--- a/main.js
+++ b/main.js
@@ -154,9 +154,9 @@ async function main() {
             ]
 
             // Used by pybuild
-            targetArchitectures.forEach(targetArchitecture => {
-                devPackages.concat("libpython3.7-minimal:" + targetArchitecture)
-            });
+            for (i in targetArchitectures) {
+                devPackages.concat("libpython3.7-minimal:" + targetArchitectures[i])
+            }
 
             return devPackages
         }

--- a/main.js
+++ b/main.js
@@ -165,12 +165,13 @@ async function main() {
                     "-a" + targetArchitecture
                 ].concat(dpkgBuildPackageOpts)
             )
+                runDockerExecStep(
+                "Run static analysis",
+                ["lintian"]
+                    .concat(lintianOpts)
+                    .concat("*" + targetArchitecture + ".changes")
+            )
         })
-
-        runDockerExecStep(
-            "Run static analysis",
-            ["lintian"].concat(lintianOpts)
-        )
 
         runDockerExecStep(
             "Move artifacts",

--- a/main.js
+++ b/main.js
@@ -35,7 +35,7 @@ async function main() {
             // (Seems to not recognize that some packages are installed)
             "-d"
         ]
-        const dpkgBuildPackageOpts = core.getInput("dpkg_buildpackage_opts") || defaultDpkgBuildPackageOpts
+        const dpkgBuildPackageOpts = core.getInput("dpkg_buildpackage_opts").replaceAll(" ", "").split(",") || defaultDpkgBuildPackageOpts
         const lintianOpts = core.getInput("lintian_opts") || []
 
         const workspaceDirectory = process.cwd()

--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ async function main() {
 
         fs.mkdirSync(artifactsDirectory, { recursive: true })
 
-        function runDockerExecStep(title, commandParams) {
+        async function runDockerExecStep(title, commandParams) {
             core.startGroup(title)
             await exec.exec("docker", [
                 "exec",

--- a/main.js
+++ b/main.js
@@ -109,7 +109,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "-yq", "dpkg-dev", "debhelper"
+            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts"
         ])
         core.endGroup()
 
@@ -117,7 +117,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "build-dep", "-yq", sourceDirectory
+            "mk-build-deps", "-ir", "-t", "apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends"
         ])
         core.endGroup()
 
@@ -125,7 +125,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "dpkg-buildpackage", "-tc"
+            "dpkg-buildpackage", "--no-sign", "-d", "-aarmhf"
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -136,6 +136,16 @@ async function main() {
         //////////////////////////////////////
         // Update packages list
         //////////////////////////////////////
+        core.startGroup("Add backports repo to apt sources")
+        await exec.exec("docker", ["exec", container].concat(
+            ["bash", "-c"].concat(
+                [
+                    "echo 'deb http://deb.debian.org/debian " + distribution + "-backports main' > /etc/apt/sources.list.d/" + distribution + "-backports.list"
+                ]
+            )
+        ))
+        core.endGroup()
+
         core.startGroup("Update packages list")
         await exec.exec("docker", ["exec", container].concat(
             ["apt-get", "update"]
@@ -160,10 +170,15 @@ async function main() {
 
             return devPackages.concat(libPythonPackages)
         }
+
         core.startGroup("Install development packages")
         await exec.exec("docker", ["exec", container].concat(
             [
-                "apt-get", "install", "--no-install-recommends", "-y"
+                "apt-get",
+                "install",
+                "-t", distribution + "-backports",
+                "--no-install-recommends",
+                "-y"
             ].concat(getDevPackages())
         ))
         core.endGroup()

--- a/main.js
+++ b/main.js
@@ -154,9 +154,9 @@ async function main() {
             ]
 
             // Used by pybuild
-            for (const targetArchitecture of targetArchitectures) {
+            targetArchitectures.forEach(targetArchitecture => {
                 devPackages.concat("libpython3.7-minimal:" + targetArchitecture)
-            }
+            });
 
             return devPackages
         }

--- a/main.js
+++ b/main.js
@@ -105,7 +105,7 @@ async function main() {
         core.endGroup()
 
         if (revision) {
-            runDockerExecStep("Create tarball", [
+            await runDockerExecStep("Create tarball", [
                 "tar",
                 "--exclude-vcs",
                 "--exclude", "./debian",
@@ -118,14 +118,14 @@ async function main() {
 
         if (targetArchitectures.length != 0) {
             targetArchitectures.forEach(targetArchitecture => {
-                runDockerExecStep(
+                await runDockerExecStep(
                     "Add target architecture: " + targetArchitecture,
                     ["dpkg", "--add-architecture", targetArchitecture]
                 )
             })
         }
 
-        runDockerExecStep(
+        await runDockerExecStep(
             "Update packages list",
             ["apt-get", "update"]
         )
@@ -145,27 +145,27 @@ async function main() {
 
             return devPackages
         }
-        runDockerExecStep(
+        await runDockerExecStep(
             "Install development packages",
             [
                 "apt-get", "install", "--no-install-recommends", "-y"
             ].concat(getDevPackages())
         )
 
-        runDockerExecStep(
+        await runDockerExecStep(
             "Install build dependencies",
             ["apt-get", "build-dep", "-y", sourceDirectory]
         )
 
         targetArchitectures.forEach(targetArchitecture => {
-            runDockerExecStep(
+            await runDockerExecStep(
                 "Build package for architecture: " + targetArchitecture,
                 [
                     "dpkg-buildpackage",
                     "-a" + targetArchitecture
                 ].concat(dpkgBuildPackageOpts)
             )
-                runDockerExecStep(
+                await runDockerExecStep(
                 "Run static analysis",
                 ["lintian"]
                     .concat(lintianOpts)
@@ -173,7 +173,7 @@ async function main() {
             )
         })
 
-        runDockerExecStep(
+        await runDockerExecStep(
             "Move artifacts",
             [
                 "find",

--- a/main.js
+++ b/main.js
@@ -109,7 +109,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts"
+            "apt-get", "install", "--no-install-recommends", "-y", "dpkg-dev", "debhelper", "devscripts", "equivs"
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -116,7 +116,7 @@ async function main() {
             ])
         }
 
-        if (targetArchitectures.length() != 0) {
+        if (targetArchitectures.length != 0) {
             for (targetArchitecture in targetArchitectures) {
                 runDockerExecStep(
                     "Add target architecture: " + targetArchitecture,

--- a/main.js
+++ b/main.js
@@ -124,13 +124,13 @@ async function main() {
         // Add target architectures
         //////////////////////////////////////
         if (targetArchitectures.length != 0) {
-            targetArchitectures.forEach(targetArchitecture => {
+            for (const targetArchitecture of targetArchitectures) {
                 core.startGroup("Add target architecture: " + targetArchitecture)
                 await exec.exec("docker", ["exec", container].concat(
                     ["dpkg", "--add-architecture", targetArchitecture]
                 ))
                 core.endGroup()
-            })
+            }
         }
 
         //////////////////////////////////////
@@ -154,9 +154,9 @@ async function main() {
             ]
 
             // Used by pybuild
-            targetArchitectures.forEach(targetArchitecture => {
+            for (const targetArchitecture of targetArchitectures) {
                 devPackages.concat("libpython3.7-minimal:" + targetArchitecture)
-            })
+            }
 
             return devPackages
         }
@@ -177,7 +177,7 @@ async function main() {
         //////////////////////////////////////
         // Build package and run static analysis for all architectures
         //////////////////////////////////////
-        targetArchitectures.forEach(targetArchitecture => {
+        for (const targetArchitecture of targetArchitectures) {
             core.startGroup("Build package for architecture: " + targetArchitecture)
             await exec.exec("docker", ["exec", container].concat(
                 [
@@ -194,7 +194,7 @@ async function main() {
                     .concat("*" + targetArchitecture + ".changes")
             ))
             core.endGroup()
-        })
+        }
 
         //////////////////////////////////////
         // Move artifacts

--- a/main.js
+++ b/main.js
@@ -121,9 +121,11 @@ async function main() {
             "exec",
             container,
             "apt-get", "install", "--no-install-recommends", "-y",
+
             // General packaging stuff
             "dpkg-dev",
             "debhelper",
+
             // Used by pybuild
             "libpython3.7-minimal:" + targetArchitecture
         ])
@@ -141,7 +143,18 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "dpkg-buildpackage", "--no-sign", "-a" + targetArchitecture
+            "dpkg-buildpackage",
+
+            // Don't sign for now
+            "--no-sign",
+
+            // Ignore build dependencies - we have already installed them
+            //
+            // Seems to not recognise if python3-all and python3-gpiozero are installed
+            // and may affect other packages in the same way - but THEY ARE THERE
+            "-d",
+
+            "-a" + targetArchitecture
         ])
         core.endGroup()
 

--- a/main.js
+++ b/main.js
@@ -65,6 +65,7 @@ async function main() {
             "--name", container,
             "--volume", workspaceDirectory + ":" + workspaceDirectory,
             "--workdir", sourceDirectory,
+            "--env", "DH_VERBOSE=1",
             "--env", "DEBIAN_FRONTEND=noninteractive",
             "--env", "DPKG_COLORS=always",
             "--env", "FORCE_UNSAFE_CONFIGURE=1",

--- a/main.js
+++ b/main.js
@@ -130,21 +130,26 @@ async function main() {
             ["apt-get", "update"]
         )
 
-        args = [
-            "apt-get", "install", "--no-install-recommends", "-y",
-            // General packaging stuff
-            "dpkg-dev",
-            "debhelper",
-            "lintian"
-        ]
+        function getDevPackages() {
+            devPackages = [
+                // General packaging stuff
+                "dpkg-dev",
+                "debhelper",
+                "lintian"
+            ]
 
-        // Used by pybuild
-        for (targetArchitecture in targetArchitectures) {
-            args.concat("libpython3.7-minimal:" + targetArchitecture)
+            // Used by pybuild
+            for (targetArchitecture in targetArchitectures) {
+                devPackages.concat("libpython3.7-minimal:" + targetArchitecture)
+            }
+
+            return devPackages
         }
         runDockerExecStep(
             "Install development packages",
-            args
+            [
+                "apt-get", "install", "--no-install-recommends", "-y"
+            ].concat(getDevPackages())
         )
 
         runDockerExecStep(

--- a/main.js
+++ b/main.js
@@ -154,11 +154,11 @@ async function main() {
             ]
 
             // Used by pybuild
-            for (i in targetArchitectures) {
-                devPackages.concat("libpython3.7-minimal:" + targetArchitectures[i])
-            }
+            const libPythonPackages = targetArchitectures.map(targetArchitecture => {
+                return "libpython3.7-minimal:" + targetArchitecture
+            })
 
-            return devPackages
+            return devPackages.concat(libPythonPackages)
         }
         core.startGroup("Install development packages")
         await exec.exec("docker", ["exec", container].concat(

--- a/main.js
+++ b/main.js
@@ -189,9 +189,15 @@ async function main() {
 
             core.startGroup("Run static analysis")
             await exec.exec("docker", ["exec", container].concat(
-                ["lintian"]
-                    .concat(lintianOpts)
-                    .concat("*" + targetArchitecture + ".changes")
+                [
+                    "find",
+                    buildDirectory,
+                    "-maxdepth", "1",
+                    "-name", `*${targetArchitecture}.changes`,
+                    "-type", "f",
+                    "-print",
+                    "-exec"
+                ]).concat(["lintian"]).concat(lintianOpts).concat(["{}", ";"]
             ))
             core.endGroup()
         }

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ async function getOS(distribution) {
 
 async function main() {
     try {
-        const targetArchitectures = core.getInput("target_architectures") || []
+        const targetArchitectures = core.getInput("target_architectures").replaceAll(" ", "").split(",") || []
 
         const sourceRelativeDirectory = core.getInput("source_directory") || "./"
         const artifactsRelativeDirectory = core.getInput("artifacts_directory") || "./"


### PR DESCRIPTION
* Enable multiple target architectures
* Add support for specifying `dpkgbuildpackage` opts
* Add support for specifying `lintian` opts
* Add support for getting dev packages from backports
* Make `dpkgbuildpackage` verbose