### PR TITLE
Symlinks are transformed as well, which leads into broken symlinks.

### DIFF
--- a/main.js
+++ b/main.js
@@ -89,7 +89,7 @@ async function main() {
                 "tar",
                 "--exclude-vcs",
                 "--exclude", "./debian",
-                "--transform", `s/^\./${package}-${version}/`,
+                "--transform", `s/^\./${package}-${version}/S`,
                 "-cvzf", `${buildDirectory}/${package}_${version}.orig.tar.gz`,
                 "-C", sourceDirectory,
                 "./"


### PR DESCRIPTION
Adding the correct transformation scope flags here.

https://www.gnu.org/software/tar/manual/html_section/tar_51.html
mentions a way to fix this:

```
In addition, several transformation scope flags are supported, that control to what files transformations apply. These are:

[...]

`S'
Do not apply transformation to symbolic link targets.
```