### PR TITLE
Fix build artifacts move

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,7 +172,7 @@ async function main() {
             "find",
             buildDirectory,
             "-maxdepth", "1",
-            "-name", `${pkg}*${version}*.*`,
+            "-name", `*${version}*.*`,
             "-type", "f",
             "-print",
             "-exec", "mv", "{}", artifactsDirectory, ";"


### PR DESCRIPTION
As you can build multiple binary packages from one source package, those
don't need to have the same name. You can even build only one binary
package which has a completely different name.
The saves way is to match on the package version number.