### PR TITLE
Disable build dependencies install on Ubuntu 14.04 (trusty)

### DIFF
--- a/main.js
+++ b/main.js
@@ -133,13 +133,15 @@ async function main() {
         ])
         core.endGroup()
 
-        core.startGroup("Install build dependencies")
-        await exec.exec("docker", [
-            "exec",
-            container,
-            "apt-get", "build-dep", "-yq", "-t", imageTag, sourceDirectory
-        ])
-        core.endGroup()
+        if (imageTag != "trusty") {
+            core.startGroup("Install build dependencies")
+            await exec.exec("docker", [
+                "exec",
+                container,
+                "apt-get", "build-dep", "-yq", "-t", imageTag, sourceDirectory
+            ])
+            core.endGroup()
+        }
 
         core.startGroup("Build packages")
         await exec.exec("docker", [


### PR DESCRIPTION
Fixes #26