### PR TITLE
install security packages

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ async function main() {
         const sourceRelativeDirectory = core.getInput("source_directory") || "./"
         const artifactsRelativeDirectory = core.getInput("artifacts_directory") || "./"
         const osDistribution = core.getInput("os_distribution") || ""
+        const extraPackages = core.getInput("extra_packages").split(' ') || []
 
         const workspaceDirectory = process.cwd()
         const sourceDirectory = path.join(workspaceDirectory, sourceRelativeDirectory)
@@ -61,6 +62,7 @@ async function main() {
             arch: cpuArchitecture,
             image: image,
             container: container,
+            extraPackages: extraPackages,
             workspaceDirectory: workspaceDirectory,
             sourceDirectory: sourceDirectory,
             buildDirectory: buildDirectory,
@@ -126,7 +128,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "apt-get", "install", "-yq", "-t", imageTag, "dpkg-dev", "debhelper", "devscripts"
+            "apt-get", "install", "-yq", "dpkg-dev", "debhelper", "devscripts"
         ])
         core.endGroup()
 
@@ -135,7 +137,7 @@ async function main() {
             await exec.exec("docker", [
                 "exec",
                 container,
-                "apt-get", "build-dep", "-yq", "-t", imageTag, sourceDirectory
+                "apt-get", "build-dep", "-yq", sourceDirectory
             ])
             core.endGroup()
         }


### PR DESCRIPTION
I had a problem with a package that required zlib1g-dev and liblzma-dev, because those have received security updates, and `-t bullseye` does not install packages from bullseye-security. Since the -t argument seemed superfluous, I simply removed it.
