### PR TITLE
tell git to trust the repo

### DIFF
--- a/main.js
+++ b/main.js
@@ -155,6 +155,15 @@ async function main() {
         ])
         core.endGroup()
 
+        core.startGroup("Trust this git repo")
+        await exec.exec("docker", [
+            "exec",
+            container,
+            "bash", "-c",
+            "git config --global --add safe.directory ${PWD}"
+        ])
+        core.endGroup()
+
         if (imageTag != "trusty") {
             core.startGroup("Install build dependencies")
             await exec.exec("docker", [

--- a/main.js
+++ b/main.js
@@ -159,8 +159,7 @@ async function main() {
         await exec.exec("docker", [
             "exec",
             container,
-            "bash", "-c",
-            "git config --global --add safe.directory ${PWD}"
+            "git", "config", "--global", "--add", "safe.directory", sourceDirectory
         ])
         core.endGroup()
 


### PR DESCRIPTION
Recent versions of git do not like to run as root in repos that are not owned by root.  This is commonly the situation when a user checks out a git repo, then runs a docker container with the repo mounted in it.

The version un debian unstable (1:2.38.1-1) has this issue.  The version in bullseye (1:2.30.2-1) does not have this issue.

git-deborig gives this unhelpful error message:

    $ git deborig HEAD
    pwd doesn't look like a git repository ..

Regular git gives this more useful error message:

    $ git status
    fatal: detected dubious ownership in repository at '/data/home/seb/action-debian-package'
    To add an exception for this directory, call:

            git config --global --add safe.directory /data/home/seb/action-debian-package

This commit fixes the issue by running the recommended command inside the container, before trying to access the git repo.

Fixes #62.