### PR TITLE
Update dropbear to 2022.83-1~bpo11+1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           - package: dropbear
             arch: amd64
             repo: https://salsa.debian.org/debian/dropbear.git
-            ref: debian/2016.74-5+deb9u1
+            ref: debian/2022.83-1_bpo11+1
             lintian_opts: "-v"
           - package: deber
             arch: arm64


### PR DESCRIPTION
Debian stretch is not available via mirrors anymore