### PR TITLE
Adding installation of skopeo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
             repo: https://github.com/dawidd6/deber.git
             ref: v1.0.0
             lintian_opts: "-v"
+            install_skopeo: true
           - package: netcat-openbsd
             arch: arm64
             repo: https://git.launchpad.net/ubuntu/+source/netcat-openbsd
@@ -52,10 +53,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Clone repo
         run: git clone --depth=1 ${{matrix.repo}} -b ${{matrix.ref}} ${{matrix.package}}
+
       - name: Remove skopeo (for testing installation)
-        run: sudo rm -f $(which skopeo)
+        if: ${{matrix.install_skopeo}}
+        run: sudo rm -v $(which skopeo)
+
       - name: Test run
         uses: ./
         with:
@@ -63,7 +68,8 @@ jobs:
           source_directory: ${{matrix.package}}
           artifacts_directory: artifacts
           lintian_opts: ${{matrix.lintian_opts}}
-          lintian_run: ${{matrix.lintian_run || false }}
+          lintian_run: ${{matrix.lintian_run || false}}
+
       - name: Check files
         run: |
           ls -lh artifacts/${{matrix.package}}*.*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Clone repo
         run: git clone --depth=1 ${{matrix.repo}} -b ${{matrix.ref}} ${{matrix.package}}
+      - name: Remove skopeo (for testing installation)
+        run: sudo rm -f $(which skopeo)
       - name: Test run
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Remove skopeo (for testing installation)
         if: ${{matrix.install_skopeo}}
-        run: sudo rm -v $(which skopeo)
+        run: sudo apt-get remove -y skopeo
 
       - name: Test run
         uses: ./

--- a/main.js
+++ b/main.js
@@ -16,9 +16,25 @@ function getImageTag(imageName, distribution) {
 }
 
 async function getImageName(distribution) {
+    const io = require('@actions/io')
     const tag = getImageTag("", distribution)
     for (const image of ["debian", "ubuntu"]) {
         try {
+            const skopeoPath = await io.which('skopeo', true)
+	    if (!skopeoPath) {
+                core.startGroup("Install skopeo")
+                await exec.exec("sudo", [
+                    "apt-get",
+                    "update"
+                ])
+                await exec.exec("sudo", [
+                    "apt-get",
+                    "-y",
+                    "install",
+                    "skopeo"
+                ])
+                core.endGroup()
+            }
             core.startGroup("Get image name")
             await exec.exec("skopeo", [
                 "inspect",

--- a/main.js
+++ b/main.js
@@ -17,24 +17,24 @@ function getImageTag(imageName, distribution) {
 }
 
 async function getImageName(distribution) {
+    const skopeoPath = await io.which('skopeo', false)
+    if (!skopeoPath) {
+        core.startGroup("Install skopeo")
+        await exec.exec("sudo", [
+            "apt-get",
+            "update"
+        ])
+        await exec.exec("sudo", [
+            "apt-get",
+            "-y",
+            "install",
+            "skopeo"
+        ])
+        core.endGroup()
+    }
     const tag = getImageTag("", distribution)
     for (const image of ["debian", "ubuntu"]) {
         try {
-            const skopeoPath = await io.which('skopeo', true)
-	    if (!skopeoPath) {
-                core.startGroup("Install skopeo")
-                await exec.exec("sudo", [
-                    "apt-get",
-                    "update"
-                ])
-                await exec.exec("sudo", [
-                    "apt-get",
-                    "-y",
-                    "install",
-                    "skopeo"
-                ])
-                core.endGroup()
-            }
             core.startGroup("Get image name")
             await exec.exec("skopeo", [
                 "inspect",

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 const core = require("@actions/core")
 const exec = require("@actions/exec")
+const io = require('@actions/io')
 const firstline = require("firstline")
 const path = require("path")
 const fs = require("fs")
@@ -16,7 +17,6 @@ function getImageTag(imageName, distribution) {
 }
 
 async function getImageName(distribution) {
-    const io = require('@actions/io')
     const tag = getImageTag("", distribution)
     for (const image of ["debian", "ubuntu"]) {
         try {


### PR DESCRIPTION
Since other platforms, beside Github Actions, can use Actions (see https://forgejo.org/docs/v1.21/user/actions/), it is not save to assume skopeo is installed by default.